### PR TITLE
Fix token fetching error

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -80,7 +80,9 @@ export class AuthComponent implements OnInit, OnDestroy {
       .then((res) => res.json())
       .then((data) => {
         if (data.error) {
-          throw new Error(data.error);
+          this.logger.info(`AuthComponent: Error authenticating, server responds with ${data.error}. Falling back on sessionStorage.`);
+          this.authService.storeOAuthAccessTokenFromSession();
+          return;
         }
         this.authService.storeOAuthAccessToken(data.token);
         this.logger.info('AuthComponent: Sucessfully obtained access token');

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -56,6 +56,16 @@ export class AuthService {
   storeOAuthAccessToken(token: string) {
     this.githubService.storeOAuthAccessToken(token);
     this.accessToken.next(token);
+    sessionStorage.setItem('token', token);
+  }
+
+  storeOAuthAccessTokenFromSession() {
+    const token = sessionStorage.getItem('token');
+    if (!token) {
+      this.logger.warn('AuthService: No value/empty string found in "token" value in sessionStorage.');
+      throw new Error('Invalid authentication token.');
+    }
+    this.storeOAuthAccessToken(token);
   }
 
   reset(): void {


### PR DESCRIPTION
### Summary:
Upon entering the page to confirm logging in, the user may clicks on the link to the official Github page. Upon navigating back, the user is thrown back to the session selection page with the error "bad_code". This PR aims to enhance the behaviour of back navigation from Github to CATcher, by staying at the confirm login page (while user can still successfully log in upon confirmation).

### Changes Made:
Store the token obtained from Github in session storage. When the application fails to fetch token from Heroku host, it falls back to session storage.

### Proposed Commit Message:
```
Enhance back-navigation behaviour

When the user navigates back from Github to CATcher confirm login page,
the application previously throws an error and the user is back
to the session selection page. Now, when fetching for token
from Heroku host, if failed, the application falls back to session storage,
so that the user can stay on confirm login page.
```
