### PR TITLE
Default branch to `main`

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -31,11 +31,14 @@ import { GithubRelease } from '../models/github/github.release';
 import { SessionData } from '../models/session.model';
 import { ERRORCODE_NOT_FOUND, ErrorHandlingService } from './error-handling.service';
 import { LoggingService } from './logging.service';
+import { throwIfFalse } from '../../shared/lib/custom-ops';
 
 const { Octokit } = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
 const CATCHER_REPO = 'CATcher';
+const BRANCH = 'main';
 const UNABLE_TO_OPEN_IN_BROWSER = 'Unable to open this issue in Browser';
+const BRANCH_CREATION_FAILED = `Unable to create ${BRANCH} branch.`;
 function getSettingsUrl(org: string, repoName: string): string {
   return `https://raw.githubusercontent.com/${org}/${repoName}/master/settings.json`;
 }
@@ -202,6 +205,84 @@ export class GithubService {
   }
 
   /**
+   * Creates the `main` branch for the current repository.
+   */
+  createBranch() {
+    return this.getDefaultBranch().pipe(
+      mergeMap((res) => this.getBranchHeadInfo(res)),
+      map((res) => res.data.object.sha),
+      mergeMap((sha: string) => this.createBranchFromCommit(sha)),
+      mergeMap(() => this.isMainBranchPresent()),
+      throwIfFalse(
+        (isBranchPresent: boolean) => isBranchPresent,
+        () => new Error(BRANCH_CREATION_FAILED)
+      )
+    );
+  }
+
+  /**
+   * Creates the `main` branch for the current repository,
+   * from the commit with the given SHA.
+   */
+  createBranchFromCommit(commitSha: string) {
+    return from(
+      octokit.git.createRef({
+        owner: ORG_NAME,
+        repo: REPO,
+        ref: `refs/heads/${BRANCH}`,
+        sha: commitSha
+      })
+    );
+  }
+
+  /**
+   * Get the default branch of the specified repository.
+   * @param owner The owner of the repository.
+   * @param repo The name of the repository.
+   */
+  getDefaultBranch(): Observable<string> {
+    return from(
+      octokit.repos.get({
+        owner: ORG_NAME,
+        repo: REPO
+      })
+    ).pipe(map((res: any) => res.data.default_branch));
+  }
+
+  /**
+   * Get information of the head of the given branch name,
+   * in the current repository.
+   * @param branch The name of the branch.
+   */
+  getBranchHeadInfo(branch: string): Observable<any> {
+    return from(
+      octokit.git.getRef({
+        owner: ORG_NAME,
+        repo: REPO,
+        ref: `heads/${branch}`
+      })
+    );
+  }
+
+  /**
+   * Checks if the repo already has the branch `main`.
+   */
+  isMainBranchPresent(): Observable<boolean> {
+    return from(
+      octokit.git.getRef({
+        owner: ORG_NAME,
+        repo: REPO,
+        ref: `heads/${BRANCH}`
+      })
+    ).pipe(
+      map((res: any) => res.status !== ERRORCODE_NOT_FOUND),
+      catchError(() => {
+        return of(false);
+      })
+    );
+  }
+
+  /**
    * Fetches information about an issue using GraphQL.
    *
    * If the issue is not modified, return a `304 - Not Modified` response.
@@ -360,7 +441,7 @@ export class GithubService {
       octokit.repos.createOrUpdateFile({
         owner: ORG_NAME,
         repo: REPO,
-        branch: 'main',
+        branch: BRANCH,
         path: `files/${filename}`,
         message: 'upload file',
         content: base64String

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -36,7 +36,7 @@ import { LoggingService } from './logging.service';
 const { Octokit } = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
 const CATCHER_REPO = 'CATcher';
-const BRANCH = 'test';
+const BRANCH = 'main';
 const UNABLE_TO_OPEN_IN_BROWSER = 'Unable to open this issue in Browser';
 const BRANCH_CREATION_FAILED = `Unable to create ${BRANCH} branch.`;
 function getSettingsUrl(org: string, repoName: string): string {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -360,6 +360,7 @@ export class GithubService {
       octokit.repos.createOrUpdateFile({
         owner: ORG_NAME,
         repo: REPO,
+        branch: 'main',
         path: `files/${filename}`,
         message: 'upload file',
         content: base64String

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -16,6 +16,7 @@ import {
   FetchLabelsQuery
 } from '../../../../graphql/graphql-types';
 import { AppConfig } from '../../../environments/environment';
+import { throwIfFalse } from '../../shared/lib/custom-ops';
 import { getNumberOfPages } from '../../shared/lib/github-paginator-parser';
 import { IssueComment } from '../models/comment.model';
 import { GithubUser } from '../models/github-user.model';
@@ -31,12 +32,11 @@ import { GithubRelease } from '../models/github/github.release';
 import { SessionData } from '../models/session.model';
 import { ERRORCODE_NOT_FOUND, ErrorHandlingService } from './error-handling.service';
 import { LoggingService } from './logging.service';
-import { throwIfFalse } from '../../shared/lib/custom-ops';
 
 const { Octokit } = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
 const CATCHER_REPO = 'CATcher';
-const BRANCH = 'main';
+const BRANCH = 'test';
 const UNABLE_TO_OPEN_IN_BROWSER = 'Unable to open this issue in Browser';
 const BRANCH_CREATION_FAILED = `Unable to create ${BRANCH} branch.`;
 function getSettingsUrl(org: string, repoName: string): string {

--- a/src/app/core/services/upload.service.ts
+++ b/src/app/core/services/upload.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
-import { throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { uuid } from '../../shared/lib/uuid';
 import { GithubService } from './github.service';
+import { catchError, mergeMap } from 'rxjs/operators';
+import { ERRORCODE_NOT_FOUND } from './error-handling.service';
 
 const SUPPORTED_VIDEO_FILE_TYPES = ['mp4', 'mov'];
 export const SUPPORTED_FILE_TYPES = [
@@ -49,7 +51,17 @@ export class UploadService {
     if (SUPPORTED_FILE_TYPES.includes(fileType.toLowerCase())) {
       base64String = base64String.split(',')[1];
       const onlineFilename = uuid();
-      return this.githubService.uploadFile(`${onlineFilename}.${fileType}`, base64String);
+      const attemptUploadFile = () => this.githubService.uploadFile(`${onlineFilename}.${fileType}`, base64String);
+      return attemptUploadFile().pipe(
+        catchError((err: any) => {
+          if (!(err.status === ERRORCODE_NOT_FOUND)) {
+            return throwError(err);
+          }
+          return of(false);
+        }),
+        mergeMap(() => this.githubService.createBranch()),
+        mergeMap(attemptUploadFile)
+      );
     } else {
       return throwError(FILE_TYPE_SUPPORT_ERROR);
     }

--- a/src/app/core/services/upload.service.ts
+++ b/src/app/core/services/upload.service.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@angular/core';
 import { of, throwError } from 'rxjs';
 import { catchError, mergeMap } from 'rxjs/operators';
 import { uuid } from '../../shared/lib/uuid';
-import { GithubService } from './github.service';
 import { ERRORCODE_NOT_FOUND } from './error-handling.service';
+import { GithubService } from './github.service';
 
 const SUPPORTED_VIDEO_FILE_TYPES = ['mp4', 'mov'];
 export const SUPPORTED_FILE_TYPES = [


### PR DESCRIPTION
### Summary:
Fixes CATcher-org/CATcher#1226

### Changes Made:
When uploading image, indicate the branch to upload to be `main`. Since there are no other github API used that makes commits, this means that default branch will be set to `main` for the first image upload.

### Proposed Commit Message:
```
Set default branch to `main`

Previously, image uploads depend on the user's default branch.
Now, we set the branch for image upload to be `main`.
Default branch will be `main` as a result.
```
