### PR TITLE
Duplicate loading icon

### DIFF
--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.html
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.html
@@ -52,9 +52,17 @@
   </mat-select>
 
   <div>
-    <span *ngIf="issue.duplicated" style="margin-top: 5px">
+    <span *ngIf="issue.duplicated && !isLoading" style="margin-top: 5px">
       {{ issue.duplicateOf ? '#' + issue.duplicateOf + ': ' + (issueService.getIssue(issue.duplicateOf) | async).title : 'Not specified' }}
     </span>
     <span *ngIf="!issue.duplicated" style="margin-top: 5px"> - </span>
+    <mat-progress-spinner
+      *ngIf="isLoading"
+      color="primary"
+      mode="indeterminate"
+      diameter="40"
+      strokeWidth="5"
+      style="margin: auto"
+    ></mat-progress-spinner>
   </div>
 </div>

--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
@@ -20,6 +20,7 @@ import { applySearchFilter } from '../../issue-tables/search-filter';
 })
 export class DuplicateOfComponent implements OnInit, OnDestroy {
   isEditing = false;
+  isLoading = false;
   duplicatedIssueList: Observable<Issue[]>;
   searchFilterCtrl: FormControl = new FormControl();
   filteredDuplicateIssueList: ReplaySubject<Issue[]> = new ReplaySubject<Issue[]>(1);
@@ -81,8 +82,12 @@ export class DuplicateOfComponent implements OnInit, OnDestroy {
 
   updateDuplicateStatus(event: MatSelectChange) {
     const latestIssue = this.getUpdatedIssue(event);
+    this.isLoading = true;
     this.issueService.updateIssueWithComment(latestIssue, latestIssue.issueComment).subscribe(
-      (issue) => this.issueUpdated.emit(issue),
+      (issue) => {
+        this.isLoading = false;
+        this.issueUpdated.emit(issue);
+      },
       (error) => this.errorHandlingService.handleError(error)
     );
   }

--- a/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.html
+++ b/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.html
@@ -8,7 +8,8 @@
       matTooltipPosition="above"
       (removed)="removeDuplicateStatus(duplicatedIssue)"
     >
-      <a class="no-underline link-grey-dark" [routerLink]="['./' + duplicatedIssue.id]"> #{{ duplicatedIssue.id }} </a>
+      <a *ngIf="!isLoading" class="no-underline link-grey-dark" [routerLink]="['./' + duplicatedIssue.id]"> #{{ duplicatedIssue.id }} </a>
+      <mat-progress-spinner *ngIf="isLoading" color="primary" mode="indeterminate" diameter="20" strokeWidth="3"></mat-progress-spinner>
       <mat-icon *ngIf="permissions.isTeamResponseEditable() || permissions.isTutorResponseEditable()" matChipRemove>cancel</mat-icon>
     </mat-chip>
   </mat-chip-list>

--- a/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.ts
+++ b/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.ts
@@ -13,6 +13,7 @@ import { PhaseService } from '../../../core/services/phase.service';
   encapsulation: ViewEncapsulation.None
 })
 export class DuplicatedIssuesComponent implements OnInit {
+  isLoading = false;
   duplicatedIssues: Observable<Issue[]>;
 
   @Input() issue: Issue;
@@ -30,8 +31,12 @@ export class DuplicatedIssuesComponent implements OnInit {
 
   removeDuplicateStatus(duplicatedIssue: Issue) {
     const latestIssue = this.getUpdatedIssueWithRemovedDuplicate(duplicatedIssue);
+    this.isLoading = true;
     this.issueService.updateIssueWithComment(latestIssue, latestIssue.issueComment).subscribe(
-      (issue) => this.issueService.updateLocalStore(issue),
+      (issue) => {
+        this.isLoading = false;
+        this.issueService.updateLocalStore(issue);
+      },
       (error) => this.errorHandlingService.handleError(error)
     );
   }


### PR DESCRIPTION
### Summary:
Add loading icon for:

* Choosing duplicate issue.
* Removing duplicate issue chips.

### Changes Made:
For the following components:
* `duplicate-of`
* `duplicated-issues`
A state (i.e. instance-level field) called `isLoading` is used to indicate whether the API is loading. When it is true, the loading icon is shown and the actual content is hidden. When it is false, the loading icon is hidden, and the actual content is shown.

### Proposed Commit Message:
```
Add loading icon for duplicate issues

While the application is attaching an issue as duplicate,
or is detaching an issue from duplicate list,
use a loading icon to indicate that it is loading.
```
