### PR TITLE
Login redirect

### DIFF
--- a/src/app/auth/confirm-login/confirm-login.component.ts
+++ b/src/app/auth/confirm-login/confirm-login.component.ts
@@ -44,8 +44,14 @@ export class ConfirmLoginComponent implements OnInit {
    */
   handleAuthSuccess() {
     this.authService.setTitleWithPhaseDetail();
-    this.router.navigateByUrl(this.phaseService.currentPhase);
     this.authService.changeAuthState(AuthState.Authenticated);
+    const nextRoute = this.authService.getNextRoute();
+    this.authService.clearNextRoute();
+    if (nextRoute && this.phaseService.isValidRoute(nextRoute)) {
+      this.router.navigateByUrl(nextRoute);
+    } else {
+      this.router.navigateByUrl(this.phaseService.currentPhase);
+    }
   }
 
   /**

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -14,6 +14,7 @@ export class AuthGuard implements CanActivate, CanLoad {
       return true;
     } else {
       this.router.navigate(['']);
+      this.auth.storeNextRoute(state.url);
       return false;
     }
   }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -96,6 +96,28 @@ export class AuthService {
     return this.authStateSource.getValue() === AuthState.Authenticated;
   }
 
+  /**
+   * Stores the route of a login-protected view before redirecting to login view.
+   * @param next The route to store.
+   */
+  storeNextRoute(next: string) {
+    sessionStorage.setItem('next', next);
+  }
+
+  /**
+   * Get the route of the login-protected view that the user initially wanted to direct to.
+   */
+  getNextRoute(): string {
+    return sessionStorage.getItem('next');
+  }
+
+  /**
+   * Clears the next route info.
+   */
+  clearNextRoute() {
+    sessionStorage.removeItem('next');
+  }
+
   changeAuthState(newAuthState: AuthState) {
     if (newAuthState === AuthState.Authenticated) {
       const sessionId = generateSessionId();

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -62,6 +62,13 @@ export class PhaseService {
     return this.phaseRepoOwners[phase];
   }
 
+  /**
+   * Checks whether the given route is allowed in this phase.
+   */
+  isValidRoute(route: string): boolean {
+    return route.startsWith('/' + this.currentPhase);
+  }
+
   fetchSessionData(): Observable<SessionData> {
     return this.githubService.fetchSettingsFile().pipe(map((data) => data as SessionData));
   }


### PR DESCRIPTION
### Summary:
Fixes CATcher-org/CATcher#1229

### Changes Made:
* Save the login-protected view in `sessionStorage`.
* Get the next route and redirect, if available, to the next route, upon successful authentication.
* Check that the route is a valid route before redirecting to it.

### Proposed Commit Message:
```
Login redirect

The page that the user wants to go to will now be saved in `sessionStorage`
so that upon successful login, the user will be redirected to that page.
Validation is done to ensure that the route is valid in the current phase
before user is redirected to that page.
```